### PR TITLE
Remove 'crop' method to use default cropping in the new CarrierWave version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## CarrierWave-Crop v0.2.2
+  * Integrate carrierwave_backgrounder
+  * Update bundler version
+  * Remove `crop` method to use default cropping in the new CarrierWave version
+
 ## CarrierWave-Crop v0.2.0
    * fixes for compatibility with rails 5
 

--- a/lib/carrierwave/crop/model_additions.rb
+++ b/lib/carrierwave/crop/model_additions.rb
@@ -76,7 +76,7 @@ module CarrierWave
       #  process crop: [:avatar, 600, 600]
       #
       # @param attachment [Symbol] Name of the attachment attribute to be cropped
-      def crop(attachment, width = nil, height = nil)
+      def crop_old(attachment, width = nil, height = nil) # no need for the new CarrierWave version
         if model.cropping?(attachment)
           x = model.send("#{attachment}_crop_x").to_i
           y = model.send("#{attachment}_crop_y").to_i

--- a/lib/carrierwave/crop/version.rb
+++ b/lib/carrierwave/crop/version.rb
@@ -1,5 +1,5 @@
 module CarrierWave
   module Crop
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
## CarrierWave-Crop v0.2.2
  * Integrate carrierwave_backgrounder
  * Update bundler version
  * Remove `crop` method to use default cropping in the new CarrierWave version
